### PR TITLE
Check if the host was already added

### DIFF
--- a/src/regress_stack/modules/nova.py
+++ b/src/regress_stack/modules/nova.py
@@ -177,6 +177,9 @@ def setup():
         )
         if core_utils.fqdn() in output:
             break
+        output = core_utils.sudo("nova-manage", ["cell_v2", "list_hosts"], user="nova")
+        if core_utils.fqdn() in output:
+            break
         time.sleep(5)
 
 


### PR DESCRIPTION
discover_hosts only reports new hosts. If the command was re-run, the loop would play out entirely.