### PR TITLE
Add optional PPA input to workflow dispatch.

### DIFF
--- a/.github/workflows/functional-tests.yaml
+++ b/.github/workflows/functional-tests.yaml
@@ -3,6 +3,10 @@ name: Functional Tests
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      ppa:
+        required: false
+        type: string
 
 
 jobs:
@@ -38,7 +42,7 @@ jobs:
           - proposed
         ppa:
           - ""
-          - ppa:ubuntu-security-proposed/ppa
+          - "${{ inputs.ppa || 'ppa:ubuntu-security-proposed/ppa' }}"
         ceph:
           - ""
           - ceph


### PR DESCRIPTION
This will allow a caller of the workflow to run test suite against PPA of their choice, which would be useful for verification of packages proposed for the active development release as well as SRUs.