### PR TITLE
Ensure process env is used when override env

### DIFF
--- a/src/regress_stack/__main__.py
+++ b/src/regress_stack/__main__.py
@@ -3,6 +3,7 @@
 
 import argparse
 import logging
+import os
 import pathlib
 import subprocess
 import typing
@@ -67,7 +68,8 @@ def collect_logs():
 
 @utils.measure_time
 def test(concurrency: int):
-    env = keystone.auth_env()
+    env = os.environ.copy()
+    env.update(keystone.auth_env())
     dir_name = "mycloud01"
     release = utils.release()
     utils.run("tempest", ["init", dir_name])


### PR DESCRIPTION
Running with env=<anything> will completely override the process given to the subprocess, and will miss the PATH from the parent, which can have extras such as `/snap/bin`, which is needed to run tempest from a snap.