### PR TITLE
Use old sources.list format in older than noble

### DIFF
--- a/tests/spread/regress-stack/task.yaml
+++ b/tests/spread/regress-stack/task.yaml
@@ -19,7 +19,9 @@ prepare: |
   Pin-Priority: 500
   EOF
     codename=$(lsb_release -sc)
-    if [ "$codename" = "jammy" ]; then
+    # noble is the first release that introduces deb822 format for sources.list
+    # https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-default/29333
+    if [[ "$codename" < "noble" ]]; then
       echo \
         "deb http://archive.ubuntu.com/ubuntu " \
         "${codename}-proposed main restricted" \


### PR DESCRIPTION
The sources.list deb822 format was introduced in Ubuntu 24.04 (noble), this change will make that older releases (e.g. jammy and focal) use the old format, without this change only jammy uses the old syntax.

Ref: https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-default/29333