### PR TITLE
placement: logs from apache2 logdir

### DIFF
--- a/src/regress_stack/modules/placement.py
+++ b/src/regress_stack/modules/placement.py
@@ -11,7 +11,10 @@ LOG = logging.getLogger(__name__)
 
 DEPENDENCIES = {keystone, mysql}
 PACKAGES = ["placement-api"]
-LOGS = ["/var/log/placement/"]  # empty?
+LOGS = [
+    "/var/log/apache2/placement_api_access.log",
+    "/var/log/apache2/placement_api_error.log",
+]
 
 CONF = "/etc/placement/placement.conf"
 URL = f"http://{core_utils.my_ip()}:8778/"


### PR DESCRIPTION
Placement is just a wsgi script; there's no long-lived process to write logs, so the only logs live under `/var/log/apache2/`.

Probably a few other logfiles that aren't captured under `/var/log/apache2/` for other modules.