### PR TITLE
list-modules: Show package dependencies

### DIFF
--- a/src/regress_stack/core/modules.py
+++ b/src/regress_stack/core/modules.py
@@ -30,8 +30,20 @@ def load_module(name: str, path: str):
     return module_loaded
 
 
+class ModuleInfo:
+    name: str
+    packages: typing.List[str]
+
+    def __init__(self, name: str, module: types.ModuleType):
+        self.name = name.rsplit(".")[-1]
+        self.packages = getattr(module, "PACKAGES")
+
+    def __str__(self):
+        return f"{self.name} ({' '.join(self.packages)})"
+
+
 def modules() -> typing.List[str]:
-    return list(module.rsplit(".")[-1] for module in _MOD_REGISTRY.keys())
+    return list(ModuleInfo(name, module) for name, module in _MOD_REGISTRY.items())
 
 
 class ModuleComp:


### PR DESCRIPTION
This is a bit faster than looking at the source code for each module (when running from git). Might also be worth listing the module deps for each module as well, but wanted to get feedback on the approach here first.