### PR TITLE
refactor: use bluestore file instead of loop devices

### DIFF
--- a/src/regress_stack/core/utils.py
+++ b/src/regress_stack/core/utils.py
@@ -134,6 +134,10 @@ def restart_apache():
     restart_service("apache2")
 
 
+def enable_service(service: str):
+    run("systemctl", ["enable", service])
+
+
 @functools.lru_cache()
 def fqdn() -> str:
     return run("hostname", ["-f"]).strip()


### PR DESCRIPTION
Refactor the ceph module to use bluestore file based OSDs. Enables reboot support for ceph.